### PR TITLE
Enable file open dialog on Android

### DIFF
--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -7,4 +7,6 @@
         <data android:scheme="http" />
       </intent>
     </queries>
+  <uses-permission android:name="android.permission.READ_MEDIA_IMAGES"/>
+  <uses-permission android:name="android.permission.CAMERA"/>
 </manifest>

--- a/android/src/main/java/ee/forgr/capacitor_inappbrowser/WebViewDialog.java
+++ b/android/src/main/java/ee/forgr/capacitor_inappbrowser/WebViewDialog.java
@@ -16,6 +16,7 @@ import android.view.View;
 import android.view.Window;
 import android.view.WindowManager;
 import android.webkit.PermissionRequest;
+import android.webkit.ValueCallback;
 import android.webkit.WebChromeClient;
 import android.webkit.WebResourceError;
 import android.webkit.WebResourceRequest;
@@ -41,6 +42,9 @@ public class WebViewDialog extends Dialog {
   private boolean isInitialized = false;
 
   public PermissionRequest currentPermissionRequest;
+  public static final int FILE_CHOOSER_REQUEST_CODE = 1000;
+  public ValueCallback<Uri> mUploadMessage;
+  public ValueCallback<Uri[]> mFilePathCallback;
 
   public interface PermissionHandler {
     void handleCameraPermissionRequest(PermissionRequest request);
@@ -95,8 +99,19 @@ public class WebViewDialog extends Dialog {
 
     _webView.setWebChromeClient(
       new WebChromeClient() {
-        // Grant permissions for cam
 
+        // Enable file open dialog
+        @Override
+        public boolean onShowFileChooser(
+          WebView webView,
+          ValueCallback<Uri[]> filePathCallback,
+          WebChromeClient.FileChooserParams fileChooserParams
+        ) {
+          openFileChooser(filePathCallback, fileChooserParams.getAcceptTypes()[0]);
+          return true;
+        }
+
+        // Grant permissions for cam
         @Override
         public void onPermissionRequest(final PermissionRequest request) {
           Log.i(
@@ -164,6 +179,17 @@ public class WebViewDialog extends Dialog {
       show();
       _options.getPluginCall().resolve();
     }
+  }
+
+  private void openFileChooser(ValueCallback<Uri[]> filePathCallback, String acceptType) {
+    mFilePathCallback = filePathCallback;
+    Intent intent = new Intent(Intent.ACTION_GET_CONTENT);
+    intent.addCategory(Intent.CATEGORY_OPENABLE);
+    intent.setType(acceptType); // Default to */*
+    activity.startActivityForResult(
+      Intent.createChooser(intent, "Select File"),
+      FILE_CHOOSER_REQUEST_CODE
+    );
   }
 
   public void reload() {


### PR DESCRIPTION
This PR introduces the handlers required to allow `<input type='file'...` to open the file picker in Android.

By default, Android webview does not implement it.