### PR TITLE
[Android Only] Introduce "white panel mode" & hardware acceleration

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,7 +174,7 @@ setUrl(options: { url: string; }) => Promise<any>
 ### addListener('urlChangeEvent', ...)
 
 ```typescript
-addListener(eventName: "urlChangeEvent", listenerFunc: UrlChangeListener) => Promise<PluginListenerHandle>
+addListener(eventName: 'urlChangeEvent', listenerFunc: UrlChangeListener) => Promise<PluginListenerHandle>
 ```
 
 Listen for url change, only for openWebView
@@ -194,7 +194,7 @@ Listen for url change, only for openWebView
 ### addListener('closeEvent', ...)
 
 ```typescript
-addListener(eventName: "closeEvent", listenerFunc: UrlChangeListener) => Promise<PluginListenerHandle>
+addListener(eventName: 'closeEvent', listenerFunc: UrlChangeListener) => Promise<PluginListenerHandle>
 ```
 
 Listen for close click only for openWebView
@@ -214,7 +214,7 @@ Listen for close click only for openWebView
 ### addListener('confirmBtnClicked', ...)
 
 ```typescript
-addListener(eventName: "confirmBtnClicked", listenerFunc: ConfirmBtnListener) => Promise<PluginListenerHandle>
+addListener(eventName: 'confirmBtnClicked', listenerFunc: ConfirmBtnListener) => Promise<PluginListenerHandle>
 ```
 
 Will be triggered when user clicks on confirm button when disclaimer is required, works only on iOS
@@ -326,6 +326,8 @@ Reload the current web page.
 | **`toolbarColor`**                     | <code>string</code>                                             | toolbarColor: color of the toolbar in hex format                                                                                                                                  | <code>'#ffffff''</code>                                    | 1.2.5  |
 | **`showArrow`**                        | <code>boolean</code>                                            | showArrow: if true an arrow would be shown instead of cross for closing the window                                                                                                | <code>false</code>                                         | 1.2.5  |
 | **`ignoreUntrustedSSLError`**          | <code>boolean</code>                                            | ignoreUntrustedSSLError: if true, the webview will ignore untrusted SSL errors allowing the user to view the website.                                                             | <code>false</code>                                         | 6.1.0  |
+| **`whitePanelMode`**                   | <code>boolean</code>                                            | useWhitePanelMode: Android only. If true, the webview will override the system theme to show status bar and navigation bar in white color.                                        |                                                            |        |
+| **`enableHardwareAcceleration`**       | <code>boolean</code>                                            | enableHardwareAcceleration: Android only. If true, the webview will use hardware acceleration to render the web content.                                                          |                                                            |        |
 
 
 #### DisclaimerOptions
@@ -417,18 +419,18 @@ Construct a type with a set of properties K of type T
 
 | Members          | Value                     |
 | ---------------- | ------------------------- |
-| **`ACTIVITY`**   | <code>"activity"</code>   |
-| **`NAVIGATION`** | <code>"navigation"</code> |
-| **`BLANK`**      | <code>"blank"</code>      |
-| **`DEFAULT`**    | <code>""</code>           |
+| **`ACTIVITY`**   | <code>'activity'</code>   |
+| **`NAVIGATION`** | <code>'navigation'</code> |
+| **`BLANK`**      | <code>'blank'</code>      |
+| **`DEFAULT`**    | <code>''</code>           |
 
 
 #### BackgroundColor
 
 | Members     | Value                |
 | ----------- | -------------------- |
-| **`WHITE`** | <code>"white"</code> |
-| **`BLACK`** | <code>"black"</code> |
+| **`WHITE`** | <code>'white'</code> |
+| **`BLACK`** | <code>'black'</code> |
 
 </docgen-api>
 

--- a/android/src/main/java/ee/forgr/capacitor_inappbrowser/InAppBrowserPlugin.java
+++ b/android/src/main/java/ee/forgr/capacitor_inappbrowser/InAppBrowserPlugin.java
@@ -338,6 +338,16 @@ public class InAppBrowserPlugin
         }
       }
     );
+
+    options.setUseWhitePanelMode(call.getBoolean("whitePanelMode", false));
+    options.setUseHardwareAcceleration(
+      call.getBoolean("enableHardwareAcceleration", false)
+    );
+
+    boolean useWhitePanelMode = options.useWhitePanelMode();
+    int defaultTheme = android.R.style.Theme_NoTitleBar;
+    int lightPanelTheme = android.R.style.Theme_Light_Panel;
+
     this.getActivity()
       .runOnUiThread(
         new Runnable() {
@@ -345,7 +355,7 @@ public class InAppBrowserPlugin
           public void run() {
             webViewDialog = new WebViewDialog(
               getContext(),
-              android.R.style.Theme_NoTitleBar,
+              useWhitePanelMode ? lightPanelTheme : defaultTheme,
               options,
               InAppBrowserPlugin.this
             );

--- a/android/src/main/java/ee/forgr/capacitor_inappbrowser/Options.java
+++ b/android/src/main/java/ee/forgr/capacitor_inappbrowser/Options.java
@@ -25,6 +25,8 @@ public class Options {
   private String ToolbarColor;
   private boolean ShowArrow;
   private boolean ignoreUntrustedSSLError;
+  private boolean useWhitePanelMode;
+  private boolean useHardwareAcceleration;
 
   public PluginCall getPluginCall() {
     return pluginCall;
@@ -198,5 +200,21 @@ public class Options {
 
   public void setIgnoreUntrustedSSLError(boolean _ignoreUntrustedSSLError) {
     this.ignoreUntrustedSSLError = _ignoreUntrustedSSLError;
+  }
+
+  public boolean useWhitePanelMode() {
+    return useWhitePanelMode;
+  }
+
+  public void setUseWhitePanelMode(boolean _useWhitePanelMode) {
+    this.useWhitePanelMode = _useWhitePanelMode;
+  }
+
+  public boolean useHardwareAcceleration() {
+    return useHardwareAcceleration;
+  }
+
+  public void setUseHardwareAcceleration(boolean _useHardwareAcceleration) {
+    this.useHardwareAcceleration = _useHardwareAcceleration;
   }
 }

--- a/android/src/main/java/ee/forgr/capacitor_inappbrowser/WebViewDialog.java
+++ b/android/src/main/java/ee/forgr/capacitor_inappbrowser/WebViewDialog.java
@@ -71,11 +71,23 @@ public class WebViewDialog extends Dialog {
   public void presentWebView() {
     requestWindowFeature(Window.FEATURE_NO_TITLE);
     setCancelable(true);
-    getWindow()
-      .setFlags(
-        WindowManager.LayoutParams.FLAG_FULLSCREEN,
-        WindowManager.LayoutParams.FLAG_FULLSCREEN
-      );
+    if (!_options.useWhitePanelMode()) {
+      getWindow()
+        .setFlags(
+          WindowManager.LayoutParams.FLAG_FULLSCREEN,
+          WindowManager.LayoutParams.FLAG_FULLSCREEN
+        );
+    }
+
+    if (_options.useHardwareAcceleration()) {
+      // Enable hardware acceleration for the webdialog window
+      getWindow()
+        .setFlags(
+          WindowManager.LayoutParams.FLAG_HARDWARE_ACCELERATED,
+          WindowManager.LayoutParams.FLAG_HARDWARE_ACCELERATED
+        );
+    }
+
     setContentView(R.layout.activity_browser);
     getWindow()
       .setLayout(
@@ -84,6 +96,16 @@ public class WebViewDialog extends Dialog {
       );
 
     this._webView = findViewById(R.id.browser_view);
+
+    if (_options.useHardwareAcceleration()) {
+      // Enable hardware acceleration
+      _webView.setLayerType(View.LAYER_TYPE_HARDWARE, null);
+    }
+
+    if (_options.useWhitePanelMode()) {
+      // Show a white view until the page is loaded
+      _webView.setBackgroundColor(Color.WHITE);
+    }
 
     _webView.getSettings().setJavaScriptEnabled(true);
     _webView.getSettings().setJavaScriptCanOpenWindowsAutomatically(true);

--- a/android/src/main/res/values/colors.xml
+++ b/android/src/main/res/values/colors.xml
@@ -2,4 +2,5 @@
 <resources>
     <color name="disable">#36262626</color>
     <color name="enable">#262626</color>
+    <color name="white">#FFFFFF</color>
 </resources>

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -212,6 +212,14 @@ export interface OpenWebViewOptions {
    * @default false
    */
   ignoreUntrustedSSLError?: boolean;
+  /**
+   * useWhitePanelMode: Android only. If true, the webview will override the system theme to show status bar and navigation bar in white color.
+   */
+  whitePanelMode?: boolean;
+  /**
+   * enableHardwareAcceleration: Android only. If true, the webview will use hardware acceleration to render the web content.
+   */
+  enableHardwareAcceleration?: boolean;
 }
 
 export interface InAppBrowserPlugin {


### PR DESCRIPTION
This pull request introduces two new features for **Android only**:

## Hardware Acceleration

Android WebViews are not as performant as their iOS counterparts and do not use hardware acceleration by default. By enabling hardware acceleration, the main render loop delivers a smoother experience and enhances performance.

This feature is introduced as an optional flag due to potential battery life tradeoffs on lower-end devices. To enable hardware acceleration, pass `enableHardwareAcceleration` to the config object.

**Note**: There is no equivalent feature for iOS, and it is not needed. Thus, this is an Android-specific feature.

## "White Panel Mode"

In some cases, developers may want to offer a sleeker experience or achieve parity between iOS and Android rendering of specific pages. 

By enabling "White Panel Mode":

- The WebView will use `Theme_Light_Panel` instead of `Theme_NoTitleBar`. This makes the safe areas render using the light theme and the system status bar visible.
- The background of the WebView changes to white, improving the perceived performance of the loading website by preventing a blink effect from black to white.

We decided to group these changes together as they both enhance cross-platform consistency and perceived performance optimizations for Android.