### PR TITLE
Bug: `viewWillAppear` resets view to default styles

### DIFF
--- a/ios/Plugin/WKWebViewController.swift
+++ b/ios/Plugin/WKWebViewController.swift
@@ -90,6 +90,7 @@ open class WKWebViewController: UIViewController {
     open var closeModalOk = ""
     open var closeModalCancel = ""
     open var ignoreUntrustedSSLError = false
+    var viewWasPresented = false
 
     func setHeaders(headers: [String: String]) {
         self.headers = headers
@@ -308,8 +309,11 @@ open class WKWebViewController: UIViewController {
 
     override open func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
-        self.setupViewElements()
-        setUpState()
+        if (!self.viewWasPresented) {
+            self.setupViewElements()
+            setUpState()
+            self.viewWasPresented = true
+        }
     }
 
     override open func viewWillDisappear(_ animated: Bool) {


### PR DESCRIPTION
The viewWillAppear method is triggered not only the first time the browser view is presented but also in other instances, such as when opening a file picker or the camera.

This change introduces a flag to check if the first presentation has already occurred, ensuring that styles are reset appropriately whenever the browser window reappears.