### PR TITLE
[FEATURE] Introduce `autoClosePatterns` support so the browser automatically closes on specific paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,7 +174,7 @@ setUrl(options: { url: string; }) => Promise<any>
 ### addListener('urlChangeEvent', ...)
 
 ```typescript
-addListener(eventName: "urlChangeEvent", listenerFunc: UrlChangeListener) => Promise<PluginListenerHandle>
+addListener(eventName: 'urlChangeEvent', listenerFunc: UrlChangeListener) => Promise<PluginListenerHandle>
 ```
 
 Listen for url change, only for openWebView
@@ -194,7 +194,7 @@ Listen for url change, only for openWebView
 ### addListener('closeEvent', ...)
 
 ```typescript
-addListener(eventName: "closeEvent", listenerFunc: UrlChangeListener) => Promise<PluginListenerHandle>
+addListener(eventName: 'closeEvent', listenerFunc: UrlChangeListener) => Promise<PluginListenerHandle>
 ```
 
 Listen for close click only for openWebView
@@ -214,7 +214,7 @@ Listen for close click only for openWebView
 ### addListener('confirmBtnClicked', ...)
 
 ```typescript
-addListener(eventName: "confirmBtnClicked", listenerFunc: ConfirmBtnListener) => Promise<PluginListenerHandle>
+addListener(eventName: 'confirmBtnClicked', listenerFunc: ConfirmBtnListener) => Promise<PluginListenerHandle>
 ```
 
 Will be triggered when user clicks on confirm button when disclaimer is required, works only on iOS
@@ -328,6 +328,7 @@ Reload the current web page.
 | **`ignoreUntrustedSSLError`**          | <code>boolean</code>                                            | ignoreUntrustedSSLError: if true, the webview will ignore untrusted SSL errors allowing the user to view the website.                                                             | <code>false</code>                                         | 6.1.0  |
 | **`whitePanelMode`**                   | <code>boolean</code>                                            | useWhitePanelMode: Android only. If true, the webview will override the system theme to show status bar and navigation bar in white color.                                        |                                                            |        |
 | **`enableHardwareAcceleration`**       | <code>boolean</code>                                            | enableHardwareAcceleration: Android only. If true, the webview will use hardware acceleration to render the web content.                                                          |                                                            |        |
+| **`autoclosePatterns`**                | <code>string[]</code>                                           | autoclosePatterns: Whenever a URL matches any of the patterns, the webview will be closed automatically.                                                                          |                                                            |        |
 
 
 #### DisclaimerOptions
@@ -419,18 +420,18 @@ Construct a type with a set of properties K of type T
 
 | Members          | Value                     |
 | ---------------- | ------------------------- |
-| **`ACTIVITY`**   | <code>"activity"</code>   |
-| **`NAVIGATION`** | <code>"navigation"</code> |
-| **`BLANK`**      | <code>"blank"</code>      |
-| **`DEFAULT`**    | <code>""</code>           |
+| **`ACTIVITY`**   | <code>'activity'</code>   |
+| **`NAVIGATION`** | <code>'navigation'</code> |
+| **`BLANK`**      | <code>'blank'</code>      |
+| **`DEFAULT`**    | <code>''</code>           |
 
 
 #### BackgroundColor
 
 | Members     | Value                |
 | ----------- | -------------------- |
-| **`WHITE`** | <code>"white"</code> |
-| **`BLACK`** | <code>"black"</code> |
+| **`WHITE`** | <code>'white'</code> |
+| **`BLACK`** | <code>'black'</code> |
 
 </docgen-api>
 

--- a/README.md
+++ b/README.md
@@ -174,7 +174,7 @@ setUrl(options: { url: string; }) => Promise<any>
 ### addListener('urlChangeEvent', ...)
 
 ```typescript
-addListener(eventName: 'urlChangeEvent', listenerFunc: UrlChangeListener) => Promise<PluginListenerHandle>
+addListener(eventName: "urlChangeEvent", listenerFunc: UrlChangeListener) => Promise<PluginListenerHandle>
 ```
 
 Listen for url change, only for openWebView
@@ -194,7 +194,7 @@ Listen for url change, only for openWebView
 ### addListener('closeEvent', ...)
 
 ```typescript
-addListener(eventName: 'closeEvent', listenerFunc: UrlChangeListener) => Promise<PluginListenerHandle>
+addListener(eventName: "closeEvent", listenerFunc: UrlChangeListener) => Promise<PluginListenerHandle>
 ```
 
 Listen for close click only for openWebView
@@ -214,7 +214,7 @@ Listen for close click only for openWebView
 ### addListener('confirmBtnClicked', ...)
 
 ```typescript
-addListener(eventName: 'confirmBtnClicked', listenerFunc: ConfirmBtnListener) => Promise<PluginListenerHandle>
+addListener(eventName: "confirmBtnClicked", listenerFunc: ConfirmBtnListener) => Promise<PluginListenerHandle>
 ```
 
 Will be triggered when user clicks on confirm button when disclaimer is required, works only on iOS
@@ -420,18 +420,18 @@ Construct a type with a set of properties K of type T
 
 | Members          | Value                     |
 | ---------------- | ------------------------- |
-| **`ACTIVITY`**   | <code>'activity'</code>   |
-| **`NAVIGATION`** | <code>'navigation'</code> |
-| **`BLANK`**      | <code>'blank'</code>      |
-| **`DEFAULT`**    | <code>''</code>           |
+| **`ACTIVITY`**   | <code>"activity"</code>   |
+| **`NAVIGATION`** | <code>"navigation"</code> |
+| **`BLANK`**      | <code>"blank"</code>      |
+| **`DEFAULT`**    | <code>""</code>           |
 
 
 #### BackgroundColor
 
 | Members     | Value                |
 | ----------- | -------------------- |
-| **`WHITE`** | <code>'white'</code> |
-| **`BLACK`** | <code>'black'</code> |
+| **`WHITE`** | <code>"white"</code> |
+| **`BLACK`** | <code>"black"</code> |
 
 </docgen-api>
 

--- a/android/src/main/java/ee/forgr/capacitor_inappbrowser/InAppBrowserPlugin.java
+++ b/android/src/main/java/ee/forgr/capacitor_inappbrowser/InAppBrowserPlugin.java
@@ -17,7 +17,6 @@ import androidx.browser.customtabs.CustomTabsClient;
 import androidx.browser.customtabs.CustomTabsIntent;
 import androidx.browser.customtabs.CustomTabsServiceConnection;
 import androidx.browser.customtabs.CustomTabsSession;
-
 import com.getcapacitor.JSArray;
 import com.getcapacitor.JSObject;
 import com.getcapacitor.PermissionState;
@@ -28,7 +27,6 @@ import com.getcapacitor.annotation.ActivityCallback;
 import com.getcapacitor.annotation.CapacitorPlugin;
 import com.getcapacitor.annotation.Permission;
 import com.getcapacitor.annotation.PermissionCallback;
-
 import java.lang.reflect.Array;
 import java.util.Iterator;
 
@@ -352,7 +350,9 @@ public class InAppBrowserPlugin
     int defaultTheme = android.R.style.Theme_NoTitleBar;
     int lightPanelTheme = android.R.style.Theme_Light_Panel;
 
-    options.setAutoClosePatterns(call.getArray("autoclosePatterns", new JSArray()));
+    options.setAutoClosePatterns(
+      call.getArray("autoclosePatterns", new JSArray())
+    );
 
     this.getActivity()
       .runOnUiThread(

--- a/android/src/main/java/ee/forgr/capacitor_inappbrowser/InAppBrowserPlugin.java
+++ b/android/src/main/java/ee/forgr/capacitor_inappbrowser/InAppBrowserPlugin.java
@@ -17,6 +17,8 @@ import androidx.browser.customtabs.CustomTabsClient;
 import androidx.browser.customtabs.CustomTabsIntent;
 import androidx.browser.customtabs.CustomTabsServiceConnection;
 import androidx.browser.customtabs.CustomTabsSession;
+
+import com.getcapacitor.JSArray;
 import com.getcapacitor.JSObject;
 import com.getcapacitor.PermissionState;
 import com.getcapacitor.Plugin;
@@ -26,6 +28,8 @@ import com.getcapacitor.annotation.ActivityCallback;
 import com.getcapacitor.annotation.CapacitorPlugin;
 import com.getcapacitor.annotation.Permission;
 import com.getcapacitor.annotation.PermissionCallback;
+
+import java.lang.reflect.Array;
 import java.util.Iterator;
 
 @CapacitorPlugin(
@@ -347,6 +351,8 @@ public class InAppBrowserPlugin
     boolean useWhitePanelMode = options.useWhitePanelMode();
     int defaultTheme = android.R.style.Theme_NoTitleBar;
     int lightPanelTheme = android.R.style.Theme_Light_Panel;
+
+    options.setAutoClosePatterns(call.getArray("autoclosePatterns", new JSArray()));
 
     this.getActivity()
       .runOnUiThread(

--- a/android/src/main/java/ee/forgr/capacitor_inappbrowser/Options.java
+++ b/android/src/main/java/ee/forgr/capacitor_inappbrowser/Options.java
@@ -1,5 +1,6 @@
 package ee.forgr.capacitor_inappbrowser;
 
+import com.getcapacitor.JSArray;
 import com.getcapacitor.JSObject;
 import com.getcapacitor.PluginCall;
 
@@ -27,6 +28,7 @@ public class Options {
   private boolean ignoreUntrustedSSLError;
   private boolean useWhitePanelMode;
   private boolean useHardwareAcceleration;
+  private JSArray autoClosePatterns;
 
   public PluginCall getPluginCall() {
     return pluginCall;
@@ -216,5 +218,13 @@ public class Options {
 
   public void setUseHardwareAcceleration(boolean _useHardwareAcceleration) {
     this.useHardwareAcceleration = _useHardwareAcceleration;
+  }
+
+  public JSArray getAutoClosePatterns() {
+    return autoClosePatterns;
+  }
+
+  public void setAutoClosePatterns(JSArray autoClosePatterns) {
+    this.autoClosePatterns = autoClosePatterns;
   }
 }

--- a/android/src/main/java/ee/forgr/capacitor_inappbrowser/WebViewDialog.java
+++ b/android/src/main/java/ee/forgr/capacitor_inappbrowser/WebViewDialog.java
@@ -29,9 +29,7 @@ import android.widget.ImageButton;
 import android.widget.TextView;
 import android.widget.Toast;
 import android.widget.Toolbar;
-
 import com.getcapacitor.JSArray;
-
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;

--- a/android/src/main/java/ee/forgr/capacitor_inappbrowser/WebViewDialog.java
+++ b/android/src/main/java/ee/forgr/capacitor_inappbrowser/WebViewDialog.java
@@ -126,6 +126,9 @@ public class WebViewDialog extends Dialog {
 
     _webView.setWebViewClient(new WebViewClient());
 
+    getWindow().getAttributes().windowAnimations =
+      com.google.android.material.R.style.Animation_Design_BottomSheetDialog;
+
     _webView.setWebChromeClient(
       new WebChromeClient() {
         // Enable file open dialog

--- a/android/src/main/java/ee/forgr/capacitor_inappbrowser/WebViewDialog.java
+++ b/android/src/main/java/ee/forgr/capacitor_inappbrowser/WebViewDialog.java
@@ -29,8 +29,12 @@ import android.widget.ImageButton;
 import android.widget.TextView;
 import android.widget.Toast;
 import android.widget.Toolbar;
+
+import com.getcapacitor.JSArray;
+
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.net.URL;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
@@ -407,6 +411,19 @@ public class WebViewDialog extends Dialog {
         @Override
         public void onPageStarted(WebView view, String url, Bitmap favicon) {
           super.onPageStarted(view, url, favicon);
+          if (_options.getAutoClosePatterns().length() != 0) {
+            try {
+              String path = new URL(url).getPath();
+              if (_options.getAutoClosePatterns().toList().contains(path)) {
+                dismiss();
+                _options.getCallbacks().urlChangeEvent(url);
+                _webView.destroy();
+              }
+            } catch (Exception e) {
+              Log.e("AUTOCLOSE", "Unable to cast autoclose params");
+            }
+          }
+
           try {
             URI uri = new URI(url);
             if (TextUtils.isEmpty(_options.getTitle())) {

--- a/ios/Plugin/InAppBrowserPlugin.swift
+++ b/ios/Plugin/InAppBrowserPlugin.swift
@@ -132,6 +132,8 @@ public class InAppBrowserPlugin: CAPPlugin {
         self.isPresentAfterPageLoad = call.getBool("isPresentAfterPageLoad", false)
         let showReloadButton = call.getBool("showReloadButton", false)
 
+        let autoClosePatterns = call.getArray("autoclosePatterns", [])
+
         DispatchQueue.main.async {
             let url = URL(string: urlString)
 
@@ -147,6 +149,7 @@ public class InAppBrowserPlugin: CAPPlugin {
             self.webViewController?.leftNavigationBarItemTypes = self.getToolbarItems(toolbarType: toolbarType)
             self.webViewController?.toolbarItemTypes = []
             self.webViewController?.doneBarButtonItemPosition = .right
+            self.webViewController?.autoClosePatterns = autoClosePatterns.map { $0 as! String }
             if call.getBool("showArrow", false) {
                 self.webViewController?.stopBarButtonItemImage = UIImage(named: "Forward@3x", in: Bundle(for: InAppBrowserPlugin.self), compatibleWith: nil)
             }

--- a/ios/Plugin/WKWebViewController.swift
+++ b/ios/Plugin/WKWebViewController.swift
@@ -352,9 +352,9 @@ open class WKWebViewController: UIViewController {
                         }
                     }
                 } else {
-                    if let fullUrlAsString = webView?.url?.absoluteString {
-                        let urlComponents = fullUrlAsString.components(separatedBy: "/")
-                        if self.autoClosePatterns.contains(urlComponents[urlComponents.count - 1]) {
+                    if let fullUrl = webView?.url {
+                        let path = fullUrl.lastPathComponent == "/" ? "/" : "/" + fullUrl.lastPathComponent
+                        if self.autoClosePatterns.contains(path) {
                             self.closeView()
                         }
                     }

--- a/ios/Plugin/WKWebViewController.swift
+++ b/ios/Plugin/WKWebViewController.swift
@@ -352,6 +352,7 @@ open class WKWebViewController: UIViewController {
                         }
                     }
                 } else {
+                    // To remove as soon as iOS < 16 is no longer supported
                     if let fullUrl = webView?.url {
                         let path = fullUrl.lastPathComponent == "/" ? "/" : "/" + fullUrl.lastPathComponent
                         if self.autoClosePatterns.contains(path) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@felix-health/inappbrowser",
-  "version": "6.0.31",
+  "version": "6.0.32",
   "description": "Capacitor plugin in app browser | Felix Health fork",
   "main": "dist/plugin.cjs.js",
   "module": "dist/esm/index.js",

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -1,4 +1,4 @@
-import type { PluginListenerHandle } from '@capacitor/core';
+import type { PluginListenerHandle } from "@capacitor/core";
 
 export interface UrlEvent {
   /**
@@ -21,14 +21,14 @@ export type UrlChangeListener = (state: UrlEvent) => void;
 export type ConfirmBtnListener = (state: BtnEvent) => void;
 
 export enum BackgroundColor {
-  WHITE = 'white',
-  BLACK = 'black',
+  WHITE = "white",
+  BLACK = "black",
 }
 export enum ToolBarType {
-  ACTIVITY = 'activity',
-  NAVIGATION = 'navigation',
-  BLANK = 'blank',
-  DEFAULT = '',
+  ACTIVITY = "activity",
+  NAVIGATION = "navigation",
+  BLANK = "blank",
+  DEFAULT = "",
 }
 
 export interface Headers {
@@ -265,20 +265,29 @@ export interface InAppBrowserPlugin {
    *
    * @since 0.0.1
    */
-  addListener(eventName: 'urlChangeEvent', listenerFunc: UrlChangeListener): Promise<PluginListenerHandle>;
+  addListener(
+    eventName: "urlChangeEvent",
+    listenerFunc: UrlChangeListener,
+  ): Promise<PluginListenerHandle>;
 
   /**
    * Listen for close click only for openWebView
    *
    * @since 0.4.0
    */
-  addListener(eventName: 'closeEvent', listenerFunc: UrlChangeListener): Promise<PluginListenerHandle>;
+  addListener(
+    eventName: "closeEvent",
+    listenerFunc: UrlChangeListener,
+  ): Promise<PluginListenerHandle>;
   /**
    * Will be triggered when user clicks on confirm button when disclaimer is required, works only on iOS
    *
    * @since 0.0.1
    */
-  addListener(eventName: 'confirmBtnClicked', listenerFunc: ConfirmBtnListener): Promise<PluginListenerHandle>;
+  addListener(
+    eventName: "confirmBtnClicked",
+    listenerFunc: ConfirmBtnListener,
+  ): Promise<PluginListenerHandle>;
 
   /**
    * Remove all listeners for this plugin.

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -1,4 +1,4 @@
-import type { PluginListenerHandle } from "@capacitor/core";
+import type { PluginListenerHandle } from '@capacitor/core';
 
 export interface UrlEvent {
   /**
@@ -21,14 +21,14 @@ export type UrlChangeListener = (state: UrlEvent) => void;
 export type ConfirmBtnListener = (state: BtnEvent) => void;
 
 export enum BackgroundColor {
-  WHITE = "white",
-  BLACK = "black",
+  WHITE = 'white',
+  BLACK = 'black',
 }
 export enum ToolBarType {
-  ACTIVITY = "activity",
-  NAVIGATION = "navigation",
-  BLANK = "blank",
-  DEFAULT = "",
+  ACTIVITY = 'activity',
+  NAVIGATION = 'navigation',
+  BLANK = 'blank',
+  DEFAULT = '',
 }
 
 export interface Headers {
@@ -220,6 +220,10 @@ export interface OpenWebViewOptions {
    * enableHardwareAcceleration: Android only. If true, the webview will use hardware acceleration to render the web content.
    */
   enableHardwareAcceleration?: boolean;
+  /**
+   * autoclosePatterns: Whenever a URL matches any of the patterns, the webview will be closed automatically.
+   */
+  autoclosePatterns?: string[];
 }
 
 export interface InAppBrowserPlugin {
@@ -261,29 +265,20 @@ export interface InAppBrowserPlugin {
    *
    * @since 0.0.1
    */
-  addListener(
-    eventName: "urlChangeEvent",
-    listenerFunc: UrlChangeListener,
-  ): Promise<PluginListenerHandle>;
+  addListener(eventName: 'urlChangeEvent', listenerFunc: UrlChangeListener): Promise<PluginListenerHandle>;
 
   /**
    * Listen for close click only for openWebView
    *
    * @since 0.4.0
    */
-  addListener(
-    eventName: "closeEvent",
-    listenerFunc: UrlChangeListener,
-  ): Promise<PluginListenerHandle>;
+  addListener(eventName: 'closeEvent', listenerFunc: UrlChangeListener): Promise<PluginListenerHandle>;
   /**
    * Will be triggered when user clicks on confirm button when disclaimer is required, works only on iOS
    *
    * @since 0.0.1
    */
-  addListener(
-    eventName: "confirmBtnClicked",
-    listenerFunc: ConfirmBtnListener,
-  ): Promise<PluginListenerHandle>;
+  addListener(eventName: 'confirmBtnClicked', listenerFunc: ConfirmBtnListener): Promise<PluginListenerHandle>;
 
   /**
    * Remove all listeners for this plugin.


### PR DESCRIPTION
## Introducing `autoClosePatterns`

By passing `autoClosePatterns` to the browser configuration object the webview will automatically close when the given path exists in the list of auto close patterns.

### Considerations

- `autoClosePatterns` must be a list of string containing exact patterns to close on, for example, `['/', '/close-me', '/close']`
- The browser modal **will close before navigation.**


This PR also adds an animation on close/open of the modal for Android. iOS includes animations already.