### PR TITLE
Introduce `openSystemBrowserLinks` 

### DIFF
--- a/README.md
+++ b/README.md
@@ -329,6 +329,7 @@ Reload the current web page.
 | **`whitePanelMode`**                   | <code>boolean</code>                                            | useWhitePanelMode: Android only. If true, the webview will override the system theme to show status bar and navigation bar in white color.                                        |                                                            |        |
 | **`enableHardwareAcceleration`**       | <code>boolean</code>                                            | enableHardwareAcceleration: Android only. If true, the webview will use hardware acceleration to render the web content.                                                          |                                                            |        |
 | **`autoclosePatterns`**                | <code>string[]</code>                                           | autoclosePatterns: Whenever a URL matches any of the patterns, the webview will be closed automatically.                                                                          |                                                            |        |
+| **`openSystemBrowserLinks`**           | <code>string[]</code>                                           | openSystemBrowserLinks: Android only: Whenever a URL matches any of the patterns, the webview will open the URL in the system browser.                                            |                                                            |        |
 
 
 #### DisclaimerOptions

--- a/android/src/main/java/ee/forgr/capacitor_inappbrowser/InAppBrowserPlugin.java
+++ b/android/src/main/java/ee/forgr/capacitor_inappbrowser/InAppBrowserPlugin.java
@@ -354,6 +354,10 @@ public class InAppBrowserPlugin
       call.getArray("autoclosePatterns", new JSArray())
     );
 
+    options.setOpenSystemBrowserList(
+      call.getArray("openSystemBrowserList", new JSArray())
+    );
+
     this.getActivity()
       .runOnUiThread(
         new Runnable() {

--- a/android/src/main/java/ee/forgr/capacitor_inappbrowser/InAppBrowserPlugin.java
+++ b/android/src/main/java/ee/forgr/capacitor_inappbrowser/InAppBrowserPlugin.java
@@ -355,7 +355,7 @@ public class InAppBrowserPlugin
     );
 
     options.setOpenSystemBrowserList(
-      call.getArray("openSystemBrowserList", new JSArray())
+      call.getArray("openSystemBrowserLinks", new JSArray())
     );
 
     this.getActivity()

--- a/android/src/main/java/ee/forgr/capacitor_inappbrowser/Options.java
+++ b/android/src/main/java/ee/forgr/capacitor_inappbrowser/Options.java
@@ -29,6 +29,7 @@ public class Options {
   private boolean useWhitePanelMode;
   private boolean useHardwareAcceleration;
   private JSArray autoClosePatterns;
+  private JSArray openSystemBrowserList;
 
   public PluginCall getPluginCall() {
     return pluginCall;
@@ -226,5 +227,13 @@ public class Options {
 
   public void setAutoClosePatterns(JSArray autoClosePatterns) {
     this.autoClosePatterns = autoClosePatterns;
+  }
+
+  public void setOpenSystemBrowserList(JSArray openSystemBrowserList) {
+    this.openSystemBrowserList = openSystemBrowserList;
+  }
+
+  public JSArray getOpenSystemBrowserList() {
+    return openSystemBrowserList;
   }
 }

--- a/android/src/main/java/ee/forgr/capacitor_inappbrowser/WebViewDialog.java
+++ b/android/src/main/java/ee/forgr/capacitor_inappbrowser/WebViewDialog.java
@@ -391,6 +391,15 @@ public class WebViewDialog extends Dialog {
           Context context = view.getContext();
           String url = request.getUrl().toString();
 
+          try {
+            if (_options.getOpenSystemBrowserList().length() != 0
+              && _options.getOpenSystemBrowserList().toList().contains(url)) {
+              openSystemBrowser(url, context);
+            }
+          } catch (Exception e) {
+            Log.e("SYSTEMBROWSERLINKS", e.getMessage());
+          }
+
           if (!url.startsWith("http") && !url.startsWith("http://")) {
             try {
               openSystemBrowser(url, context);

--- a/android/src/main/java/ee/forgr/capacitor_inappbrowser/WebViewDialog.java
+++ b/android/src/main/java/ee/forgr/capacitor_inappbrowser/WebViewDialog.java
@@ -395,6 +395,7 @@ public class WebViewDialog extends Dialog {
             if (_options.getOpenSystemBrowserList().length() != 0
               && _options.getOpenSystemBrowserList().toList().contains(url)) {
               openSystemBrowser(url, context);
+              return true;
             }
           } catch (Exception e) {
             Log.e("SYSTEMBROWSERLINKS", e.getMessage());

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@felix-health/inappbrowser",
-  "version": "6.0.35",
+  "version": "6.0.36",
   "description": "Capacitor plugin in app browser | Felix Health fork",
   "main": "dist/plugin.cjs.js",
   "module": "dist/esm/index.js",

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -1,4 +1,4 @@
-import type { PluginListenerHandle } from "@capacitor/core";
+import type { PluginListenerHandle } from '@capacitor/core';
 
 export interface UrlEvent {
   /**
@@ -21,14 +21,14 @@ export type UrlChangeListener = (state: UrlEvent) => void;
 export type ConfirmBtnListener = (state: BtnEvent) => void;
 
 export enum BackgroundColor {
-  WHITE = "white",
-  BLACK = "black",
+  WHITE = 'white',
+  BLACK = 'black',
 }
 export enum ToolBarType {
-  ACTIVITY = "activity",
-  NAVIGATION = "navigation",
-  BLANK = "blank",
-  DEFAULT = "",
+  ACTIVITY = 'activity',
+  NAVIGATION = 'navigation',
+  BLANK = 'blank',
+  DEFAULT = '',
 }
 
 export interface Headers {
@@ -224,6 +224,11 @@ export interface OpenWebViewOptions {
    * autoclosePatterns: Whenever a URL matches any of the patterns, the webview will be closed automatically.
    */
   autoclosePatterns?: string[];
+  /**
+   * openSystemBrowserLinks: Android only: Whenever a URL matches any of the patterns, the webview will open the URL in the system browser.
+   *
+   */
+  openSystemBrowserLinks?: string[];
 }
 
 export interface InAppBrowserPlugin {
@@ -265,29 +270,20 @@ export interface InAppBrowserPlugin {
    *
    * @since 0.0.1
    */
-  addListener(
-    eventName: "urlChangeEvent",
-    listenerFunc: UrlChangeListener,
-  ): Promise<PluginListenerHandle>;
+  addListener(eventName: 'urlChangeEvent', listenerFunc: UrlChangeListener): Promise<PluginListenerHandle>;
 
   /**
    * Listen for close click only for openWebView
    *
    * @since 0.4.0
    */
-  addListener(
-    eventName: "closeEvent",
-    listenerFunc: UrlChangeListener,
-  ): Promise<PluginListenerHandle>;
+  addListener(eventName: 'closeEvent', listenerFunc: UrlChangeListener): Promise<PluginListenerHandle>;
   /**
    * Will be triggered when user clicks on confirm button when disclaimer is required, works only on iOS
    *
    * @since 0.0.1
    */
-  addListener(
-    eventName: "confirmBtnClicked",
-    listenerFunc: ConfirmBtnListener,
-  ): Promise<PluginListenerHandle>;
+  addListener(eventName: 'confirmBtnClicked', listenerFunc: ConfirmBtnListener): Promise<PluginListenerHandle>;
 
   /**
    * Remove all listeners for this plugin.


### PR DESCRIPTION
This PR introduces a new **Android only** feature. When `openSystemBrowserLinks` is set, the webview will trigger the system browser to open the specific URL match.