### PR TITLE
Show system alert to enable camera permission

### DIFF
--- a/android/src/main/java/ee/forgr/capacitor_inappbrowser/InAppBrowserPlugin.java
+++ b/android/src/main/java/ee/forgr/capacitor_inappbrowser/InAppBrowserPlugin.java
@@ -17,6 +17,8 @@ import androidx.browser.customtabs.CustomTabsClient;
 import androidx.browser.customtabs.CustomTabsIntent;
 import androidx.browser.customtabs.CustomTabsServiceConnection;
 import androidx.browser.customtabs.CustomTabsSession;
+import androidx.core.app.ActivityCompat;
+import androidx.core.content.ContextCompat;
 import com.getcapacitor.JSArray;
 import com.getcapacitor.JSObject;
 import com.getcapacitor.PermissionState;
@@ -29,8 +31,6 @@ import com.getcapacitor.annotation.Permission;
 import com.getcapacitor.annotation.PermissionCallback;
 import java.lang.reflect.Array;
 import java.util.Iterator;
-import androidx.core.app.ActivityCompat;
-import androidx.core.content.ContextCompat;
 
 @CapacitorPlugin(
   name = "InAppBrowser",
@@ -332,7 +332,7 @@ public class InAppBrowserPlugin
         public void urlChangeEvent(String url) {
           // camera permission check when url contains camera-permission
           String query = url.substring(url.indexOf("?") + 1);
-          if(query.contains("camera-permission")){
+          if (query.contains("camera-permission")) {
             checkCameraPermission(InAppBrowserPlugin.this.getActivity());
           }
 
@@ -392,8 +392,18 @@ public class InAppBrowserPlugin
   }
 
   private void checkCameraPermission(Activity activity) {
-    if (ContextCompat.checkSelfPermission(getContext(), Manifest.permission.CAMERA) != PackageManager.PERMISSION_GRANTED) {
-      ActivityCompat.requestPermissions(activity, new String[]{ Manifest.permission.CAMERA }, REQUEST_CAMERA_PERMISSION);
+    if (
+      ContextCompat.checkSelfPermission(
+        getContext(),
+        Manifest.permission.CAMERA
+      ) !=
+      PackageManager.PERMISSION_GRANTED
+    ) {
+      ActivityCompat.requestPermissions(
+        activity,
+        new String[] { Manifest.permission.CAMERA },
+        REQUEST_CAMERA_PERMISSION
+      );
     }
   }
 

--- a/android/src/main/java/ee/forgr/capacitor_inappbrowser/WebViewDialog.java
+++ b/android/src/main/java/ee/forgr/capacitor_inappbrowser/WebViewDialog.java
@@ -219,7 +219,7 @@ public class WebViewDialog extends Dialog {
             builder.setMessage(R.string.camera_permission_alert_message);
 
             builder.setPositiveButton(
-              "Go to settings",
+              R.string.camera_permission_alert_positive,
               new DialogInterface.OnClickListener() {
                 @Override
                 public void onClick(DialogInterface dialog, int which) {
@@ -237,7 +237,7 @@ public class WebViewDialog extends Dialog {
             );
 
             builder.setNegativeButton(
-              "Cancel",
+              R.string.camera_permission_alert_negative,
               new DialogInterface.OnClickListener() {
                 @Override
                 public void onClick(DialogInterface dialog, int which) {

--- a/android/src/main/java/ee/forgr/capacitor_inappbrowser/WebViewDialog.java
+++ b/android/src/main/java/ee/forgr/capacitor_inappbrowser/WebViewDialog.java
@@ -198,6 +198,33 @@ public class WebViewDialog extends Dialog {
           chooserIntent.putExtra(Intent.EXTRA_TITLE, "Image Chooser");
           chooserIntent.putExtra(Intent.EXTRA_INITIAL_INTENTS, intentArray);
 
+          if (ContextCompat.checkSelfPermission(getContext(), Manifest.permission.CAMERA) != PackageManager.PERMISSION_GRANTED) {
+            AlertDialog.Builder builder = new AlertDialog.Builder(getContext(), com.google.android.material.R.style.Theme_AppCompat_Light_Dialog_Alert);
+            builder.setTitle(R.string.camera_permission_alert_title);
+            builder.setMessage(R.string.camera_permission_alert_message);
+
+            builder.setPositiveButton("Go to settings", new DialogInterface.OnClickListener() {
+              @Override
+              public void onClick(DialogInterface dialog, int which) {
+                // Redirect to settings
+                Intent intent = new Intent();
+                intent.setAction(android.provider.Settings.ACTION_APPLICATION_DETAILS_SETTINGS);
+                intent.setData(Uri.parse("package:" + getContext().getPackageName()));
+                getContext().startActivity(intent);
+              }
+            });
+
+            builder.setNegativeButton("Cancel", new DialogInterface.OnClickListener() {
+              @Override
+              public void onClick(DialogInterface dialog, int which) {
+                // Cancel
+              }
+            });
+
+            builder.show();
+            return false;
+          }
+
           activity.startActivityForResult(chooserIntent, FILE_CHOOSER_REQUEST_CODE);
           return true;
         }

--- a/android/src/main/java/ee/forgr/capacitor_inappbrowser/WebViewDialog.java
+++ b/android/src/main/java/ee/forgr/capacitor_inappbrowser/WebViewDialog.java
@@ -223,15 +223,7 @@ public class WebViewDialog extends Dialog {
               new DialogInterface.OnClickListener() {
                 @Override
                 public void onClick(DialogInterface dialog, int which) {
-                  // Redirect to settings
-                  Intent intent = new Intent();
-                  intent.setAction(
-                    android.provider.Settings.ACTION_APPLICATION_DETAILS_SETTINGS
-                  );
-                  intent.setData(
-                    Uri.parse("package:" + getContext().getPackageName())
-                  );
-                  getContext().startActivity(intent);
+                  goToSettings();
                 }
               }
             );
@@ -664,5 +656,13 @@ public class WebViewDialog extends Dialog {
     Intent intent = new Intent(Intent.ACTION_VIEW, Uri.parse(url));
     intent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
     context.startActivity(intent);
+  }
+
+  private void goToSettings() {
+    Intent intent = new Intent();
+    intent.setAction(android.provider.Settings.ACTION_APPLICATION_DETAILS_SETTINGS);
+    Uri uri = Uri.fromParts("package", getContext().getPackageName(), null);
+    intent.setData(uri);
+    getContext().startActivity(intent);
   }
 }

--- a/android/src/main/java/ee/forgr/capacitor_inappbrowser/WebViewDialog.java
+++ b/android/src/main/java/ee/forgr/capacitor_inappbrowser/WebViewDialog.java
@@ -34,27 +34,24 @@ import android.widget.ImageButton;
 import android.widget.TextView;
 import android.widget.Toast;
 import android.widget.Toolbar;
-
 import androidx.activity.result.ActivityResult;
 import androidx.activity.result.ActivityResultCallback;
 import androidx.activity.result.ActivityResultLauncher;
 import androidx.activity.result.contract.ActivityResultContracts;
 import androidx.core.content.ContextCompat;
 import androidx.core.content.FileProvider;
-
 import com.getcapacitor.JSArray;
-
 import java.io.File;
+import java.io.File;
+import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
+import java.text.SimpleDateFormat;
+import java.util.Date;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
-import java.io.File;
-import java.io.IOException;
-import java.text.SimpleDateFormat;
-import java.util.Date;
 
 public class WebViewDialog extends Dialog {
 
@@ -162,20 +159,29 @@ public class WebViewDialog extends Dialog {
         ) {
           mFilePathCallback = filePathCallback;
 
-          Intent takePictureIntent = new Intent(MediaStore.ACTION_IMAGE_CAPTURE);
-          if (takePictureIntent.resolveActivity(_context.getPackageManager()) != null) {
-              // Create the File where the photo should go
+          Intent takePictureIntent = new Intent(
+            MediaStore.ACTION_IMAGE_CAPTURE
+          );
+          if (
+            takePictureIntent.resolveActivity(_context.getPackageManager()) !=
+            null
+          ) {
+            // Create the File where the photo should go
             File photoFile = null;
             try {
-                photoFile = createImageFile();
+              photoFile = createImageFile();
             } catch (IOException ex) {
-                // Error occurred while creating the File
-                Log.e(TAG, "Unable to create Image File", ex);
+              // Error occurred while creating the File
+              Log.e(TAG, "Unable to create Image File", ex);
             }
 
             // Continue only if the File was successfully created
             if (photoFile != null) {
-              Uri photoURI = FileProvider.getUriForFile(getContext(), getContext().getPackageName() + ".fileprovider", photoFile);
+              Uri photoURI = FileProvider.getUriForFile(
+                getContext(),
+                getContext().getPackageName() + ".fileprovider",
+                photoFile
+              );
               takePictureIntent.putExtra("PhotoPath", photoURI);
               capturedImageUri = photoURI;
               takePictureIntent.putExtra(MediaStore.EXTRA_OUTPUT, photoURI);
@@ -187,8 +193,8 @@ public class WebViewDialog extends Dialog {
           contentSelectionIntent.setType(fileChooserParams.getAcceptTypes()[0]);
 
           Intent[] intentArray;
-          if(takePictureIntent != null) {
-            intentArray = new Intent[]{takePictureIntent};
+          if (takePictureIntent != null) {
+            intentArray = new Intent[] { takePictureIntent };
           } else {
             intentArray = new Intent[0];
           }
@@ -198,34 +204,56 @@ public class WebViewDialog extends Dialog {
           chooserIntent.putExtra(Intent.EXTRA_TITLE, "Image Chooser");
           chooserIntent.putExtra(Intent.EXTRA_INITIAL_INTENTS, intentArray);
 
-          if (ContextCompat.checkSelfPermission(getContext(), Manifest.permission.CAMERA) != PackageManager.PERMISSION_GRANTED) {
-            AlertDialog.Builder builder = new AlertDialog.Builder(getContext(), com.google.android.material.R.style.Theme_AppCompat_Light_Dialog_Alert);
+          if (
+            ContextCompat.checkSelfPermission(
+              getContext(),
+              Manifest.permission.CAMERA
+            ) !=
+            PackageManager.PERMISSION_GRANTED
+          ) {
+            AlertDialog.Builder builder = new AlertDialog.Builder(
+              getContext(),
+              com.google.android.material.R.style.Theme_AppCompat_Light_Dialog_Alert
+            );
             builder.setTitle(R.string.camera_permission_alert_title);
             builder.setMessage(R.string.camera_permission_alert_message);
 
-            builder.setPositiveButton("Go to settings", new DialogInterface.OnClickListener() {
-              @Override
-              public void onClick(DialogInterface dialog, int which) {
-                // Redirect to settings
-                Intent intent = new Intent();
-                intent.setAction(android.provider.Settings.ACTION_APPLICATION_DETAILS_SETTINGS);
-                intent.setData(Uri.parse("package:" + getContext().getPackageName()));
-                getContext().startActivity(intent);
+            builder.setPositiveButton(
+              "Go to settings",
+              new DialogInterface.OnClickListener() {
+                @Override
+                public void onClick(DialogInterface dialog, int which) {
+                  // Redirect to settings
+                  Intent intent = new Intent();
+                  intent.setAction(
+                    android.provider.Settings.ACTION_APPLICATION_DETAILS_SETTINGS
+                  );
+                  intent.setData(
+                    Uri.parse("package:" + getContext().getPackageName())
+                  );
+                  getContext().startActivity(intent);
+                }
               }
-            });
+            );
 
-            builder.setNegativeButton("Cancel", new DialogInterface.OnClickListener() {
-              @Override
-              public void onClick(DialogInterface dialog, int which) {
-                // Cancel
+            builder.setNegativeButton(
+              "Cancel",
+              new DialogInterface.OnClickListener() {
+                @Override
+                public void onClick(DialogInterface dialog, int which) {
+                  // Cancel
+                }
               }
-            });
+            );
 
             builder.show();
             return false;
           }
 
-          activity.startActivityForResult(chooserIntent, FILE_CHOOSER_REQUEST_CODE);
+          activity.startActivityForResult(
+            chooserIntent,
+            FILE_CHOOSER_REQUEST_CODE
+          );
           return true;
         }
 
@@ -297,7 +325,7 @@ public class WebViewDialog extends Dialog {
     }
   }
 
-   /**
+  /**
    * More info this method can be found at
    * http://developer.android.com/training/camera/photobasics.html
    *
@@ -306,13 +334,16 @@ public class WebViewDialog extends Dialog {
    */
   private File createImageFile() throws IOException {
     // Create an image file name
-    String timeStamp = new SimpleDateFormat("yyyyMMdd_HHmmss").format(new Date());
+    String timeStamp = new SimpleDateFormat("yyyyMMdd_HHmmss").format(
+      new Date()
+    );
     String imageFileName = "JPEG_" + timeStamp + "_";
-    File storageDir = getContext().getExternalFilesDir(Environment.DIRECTORY_PICTURES);
+    File storageDir = getContext()
+      .getExternalFilesDir(Environment.DIRECTORY_PICTURES);
     File image = File.createTempFile(
-        imageFileName,  /* prefix */
-        ".jpg",         /* suffix */
-        storageDir      /* directory */
+      imageFileName,/* prefix */
+      ".jpg",/* suffix */
+      storageDir/* directory */
     );
 
     // Save a file: path for use with ACTION_VIEW intents
@@ -488,8 +519,10 @@ public class WebViewDialog extends Dialog {
           String url = request.getUrl().toString();
 
           try {
-            if (_options.getOpenSystemBrowserList().length() != 0
-              && _options.getOpenSystemBrowserList().toList().contains(url)) {
+            if (
+              _options.getOpenSystemBrowserList().length() != 0 &&
+              _options.getOpenSystemBrowserList().toList().contains(url)
+            ) {
               openSystemBrowser(url, context);
               return true;
             }

--- a/android/src/main/res/values/strings.xml
+++ b/android/src/main/res/values/strings.xml
@@ -7,4 +7,6 @@
     <string name="back_button">Back Button</string>
     <string name="title">Title</string>
     <string name="forward_button">Forward Button</string>
+    <string name="camera_permission_alert_title">Enable camera access?</string>
+    <string name="camera_permission_alert_message">Camera access can be enabled from your system settings.</string>
 </resources>

--- a/android/src/main/res/values/strings.xml
+++ b/android/src/main/res/values/strings.xml
@@ -9,4 +9,6 @@
     <string name="forward_button">Forward Button</string>
     <string name="camera_permission_alert_title">Enable camera access?</string>
     <string name="camera_permission_alert_message">Camera access can be enabled from your system settings.</string>
+    <string name="camera_permission_alert_positive">Go to settings</string>
+    <string name="camera_permission_alert_negative">Cancel</string>
 </resources>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@felix-health/inappbrowser",
-  "version": "6.0.37",
+  "version": "6.0.38",
   "description": "Capacitor plugin in app browser | Felix Health fork",
   "main": "dist/plugin.cjs.js",
   "module": "dist/esm/index.js",

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -1,4 +1,4 @@
-import type { PluginListenerHandle } from '@capacitor/core';
+import type { PluginListenerHandle } from "@capacitor/core";
 
 export interface UrlEvent {
   /**
@@ -21,14 +21,14 @@ export type UrlChangeListener = (state: UrlEvent) => void;
 export type ConfirmBtnListener = (state: BtnEvent) => void;
 
 export enum BackgroundColor {
-  WHITE = 'white',
-  BLACK = 'black',
+  WHITE = "white",
+  BLACK = "black",
 }
 export enum ToolBarType {
-  ACTIVITY = 'activity',
-  NAVIGATION = 'navigation',
-  BLANK = 'blank',
-  DEFAULT = '',
+  ACTIVITY = "activity",
+  NAVIGATION = "navigation",
+  BLANK = "blank",
+  DEFAULT = "",
 }
 
 export interface Headers {
@@ -270,20 +270,29 @@ export interface InAppBrowserPlugin {
    *
    * @since 0.0.1
    */
-  addListener(eventName: 'urlChangeEvent', listenerFunc: UrlChangeListener): Promise<PluginListenerHandle>;
+  addListener(
+    eventName: "urlChangeEvent",
+    listenerFunc: UrlChangeListener,
+  ): Promise<PluginListenerHandle>;
 
   /**
    * Listen for close click only for openWebView
    *
    * @since 0.4.0
    */
-  addListener(eventName: 'closeEvent', listenerFunc: UrlChangeListener): Promise<PluginListenerHandle>;
+  addListener(
+    eventName: "closeEvent",
+    listenerFunc: UrlChangeListener,
+  ): Promise<PluginListenerHandle>;
   /**
    * Will be triggered when user clicks on confirm button when disclaimer is required, works only on iOS
    *
    * @since 0.0.1
    */
-  addListener(eventName: 'confirmBtnClicked', listenerFunc: ConfirmBtnListener): Promise<PluginListenerHandle>;
+  addListener(
+    eventName: "confirmBtnClicked",
+    listenerFunc: ConfirmBtnListener,
+  ): Promise<PluginListenerHandle>;
 
   /**
    * Remove all listeners for this plugin.


### PR DESCRIPTION
This PR adds an additional permissions check to avoid a situation where camera access has not been granted and the picker would show a camera button that does nothing.